### PR TITLE
Fixed issue with Roles not being shown for guests

### DIFF
--- a/CredIT/.idea/dataSources/37e3df4c-413f-41df-b74a-639d31217546.xml
+++ b/CredIT/.idea/dataSources/37e3df4c-413f-41df-b74a-639d31217546.xml
@@ -1,0 +1,801 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dataSource name="credit_db@localhost">
+  <database-model serializer="dbm" dbms="POSTGRES" family-id="POSTGRES" format-version="4.18">
+    <root id="1">
+      <ServerVersion>12.2</ServerVersion>
+      <StartupTime>1587628836</StartupTime>
+    </root>
+    <database id="2" parent="1" name="credit_db">
+      <ObjectId>196775</ObjectId>
+      <Owner>postgres</Owner>
+      <IntrospectionStateNumber>975</IntrospectionStateNumber>
+      <Current>1</Current>
+      <Relations>sequence|table|196896|196898|1
+sequence|table|196906|196908|1
+sequence|table|196929|196931|1
+sequence|table|196952|196954|1
+sequence|table|196962|196964|1
+</Relations>
+    </database>
+    <database id="3" parent="1" name="healthos">
+      <ObjectId>196631</ObjectId>
+      <Owner>postgres</Owner>
+    </database>
+    <database id="4" parent="1" name="postgres">
+      <ObjectId>13637</ObjectId>
+      <Comment>default administrative connection database</Comment>
+      <Owner>postgres</Owner>
+    </database>
+    <role id="5" parent="1" name="pg_execute_server_program">
+      <ObjectId>4571</ObjectId>
+    </role>
+    <role id="6" parent="1" name="pg_monitor">
+      <ObjectId>3373</ObjectId>
+    </role>
+    <role id="7" parent="1" name="pg_read_all_settings">
+      <ObjectId>3374</ObjectId>
+    </role>
+    <role id="8" parent="1" name="pg_read_all_stats">
+      <ObjectId>3375</ObjectId>
+    </role>
+    <role id="9" parent="1" name="pg_read_server_files">
+      <ObjectId>4569</ObjectId>
+    </role>
+    <role id="10" parent="1" name="pg_signal_backend">
+      <ObjectId>4200</ObjectId>
+    </role>
+    <role id="11" parent="1" name="pg_stat_scan_tables">
+      <ObjectId>3377</ObjectId>
+    </role>
+    <role id="12" parent="1" name="pg_write_server_files">
+      <ObjectId>4570</ObjectId>
+    </role>
+    <role id="13" parent="1" name="postgres">
+      <ObjectId>10</ObjectId>
+      <SuperRole>1</SuperRole>
+      <CreateDb>1</CreateDb>
+      <CreateRole>1</CreateRole>
+      <CanLogin>1</CanLogin>
+      <Replication>1</Replication>
+      <BypassRls>1</BypassRls>
+    </role>
+    <schema id="14" parent="2" name="information_schema">
+      <ObjectId>13337</ObjectId>
+      <StateNumber>282</StateNumber>
+      <Owner>postgres</Owner>
+    </schema>
+    <schema id="15" parent="2" name="pg_catalog">
+      <ObjectId>11</ObjectId>
+      <Comment>system catalog schema</Comment>
+      <StateNumber>275</StateNumber>
+      <Owner>postgres</Owner>
+    </schema>
+    <schema id="16" parent="2" name="public">
+      <ObjectId>2200</ObjectId>
+      <Comment>standard public schema</Comment>
+      <StateNumber>276</StateNumber>
+      <Owner>postgres</Owner>
+      <IntrospectionStateNumber>976</IntrospectionStateNumber>
+      <Current>1</Current>
+    </schema>
+    <access-method id="17" parent="2" name="heap">
+      <ObjectId>2</ObjectId>
+      <Comment>heap table access method</Comment>
+      <StateNumber>1</StateNumber>
+      <Handler>pg_catalog.heap_tableam_handler</Handler>
+      <HandlerId>3</HandlerId>
+    </access-method>
+    <access-method id="18" parent="2" name="btree">
+      <ObjectId>403</ObjectId>
+      <Comment>b-tree index access method</Comment>
+      <StateNumber>1</StateNumber>
+      <Handler>pg_catalog.bthandler</Handler>
+      <HandlerId>330</HandlerId>
+      <Type>index</Type>
+    </access-method>
+    <access-method id="19" parent="2" name="hash">
+      <ObjectId>405</ObjectId>
+      <Comment>hash index access method</Comment>
+      <StateNumber>1</StateNumber>
+      <Handler>pg_catalog.hashhandler</Handler>
+      <HandlerId>331</HandlerId>
+      <Type>index</Type>
+    </access-method>
+    <access-method id="20" parent="2" name="gist">
+      <ObjectId>783</ObjectId>
+      <Comment>GiST index access method</Comment>
+      <StateNumber>1</StateNumber>
+      <Handler>pg_catalog.gisthandler</Handler>
+      <HandlerId>332</HandlerId>
+      <Type>index</Type>
+    </access-method>
+    <access-method id="21" parent="2" name="gin">
+      <ObjectId>2742</ObjectId>
+      <Comment>GIN index access method</Comment>
+      <StateNumber>1</StateNumber>
+      <Handler>pg_catalog.ginhandler</Handler>
+      <HandlerId>333</HandlerId>
+      <Type>index</Type>
+    </access-method>
+    <access-method id="22" parent="2" name="spgist">
+      <ObjectId>4000</ObjectId>
+      <Comment>SP-GiST index access method</Comment>
+      <StateNumber>1</StateNumber>
+      <Handler>pg_catalog.spghandler</Handler>
+      <HandlerId>334</HandlerId>
+      <Type>index</Type>
+    </access-method>
+    <access-method id="23" parent="2" name="brin">
+      <ObjectId>3580</ObjectId>
+      <Comment>block range index (BRIN) access method</Comment>
+      <StateNumber>1</StateNumber>
+      <Handler>pg_catalog.brinhandler</Handler>
+      <HandlerId>335</HandlerId>
+      <Type>index</Type>
+    </access-method>
+    <extension id="24" parent="2" name="plpgsql">
+      <ObjectId>13623</ObjectId>
+      <Comment>PL/pgSQL procedural language</Comment>
+      <StateNumber>437</StateNumber>
+      <Version>1.0</Version>
+      <SchemaName>pg_catalog</SchemaName>
+      <SchemaId>11</SchemaId>
+    </extension>
+    <language id="25" parent="2" name="c"/>
+    <language id="26" parent="2" name="internal"/>
+    <language id="27" parent="2" name="plpgsql"/>
+    <language id="28" parent="2" name="sql"/>
+    <sequence id="29" parent="16" name="broadcast_id_seq">
+      <ObjectId>196962</ObjectId>
+      <StateNumber>878</StateNumber>
+      <Owner>postgres</Owner>
+      <SequenceIdentity>1</SequenceIdentity>
+      <CacheSize>1</CacheSize>
+      <DataType>integer|0s</DataType>
+    </sequence>
+    <sequence id="30" parent="16" name="cast_members_id_seq">
+      <ObjectId>196929</ObjectId>
+      <StateNumber>878</StateNumber>
+      <Owner>postgres</Owner>
+      <SequenceIdentity>1</SequenceIdentity>
+      <CacheSize>1</CacheSize>
+      <DataType>integer|0s</DataType>
+    </sequence>
+    <sequence id="31" parent="16" name="movie_id_seq">
+      <ObjectId>196906</ObjectId>
+      <StateNumber>878</StateNumber>
+      <Owner>postgres</Owner>
+      <SequenceIdentity>1</SequenceIdentity>
+      <CacheSize>1</CacheSize>
+      <DataType>integer|0s</DataType>
+    </sequence>
+    <sequence id="32" parent="16" name="production_company_id_seq">
+      <ObjectId>196896</ObjectId>
+      <StateNumber>878</StateNumber>
+      <Owner>postgres</Owner>
+      <SequenceIdentity>1</SequenceIdentity>
+      <CacheSize>1</CacheSize>
+      <DataType>integer|0s</DataType>
+    </sequence>
+    <sequence id="33" parent="16" name="production_id_seq">
+      <ObjectId>196952</ObjectId>
+      <StateNumber>878</StateNumber>
+      <Owner>postgres</Owner>
+      <SequenceIdentity>1</SequenceIdentity>
+      <CacheSize>1</CacheSize>
+      <DataType>integer|0s</DataType>
+    </sequence>
+    <table id="34" parent="16" name="broadcast">
+      <ObjectId>196964</ObjectId>
+      <Owner>postgres</Owner>
+      <StateNumber>878</StateNumber>
+    </table>
+    <table id="35" parent="16" name="broadcast_employs">
+      <ObjectId>196970</ObjectId>
+      <Owner>postgres</Owner>
+      <StateNumber>878</StateNumber>
+    </table>
+    <table id="36" parent="16" name="cast_members">
+      <ObjectId>196931</ObjectId>
+      <Owner>postgres</Owner>
+      <StateNumber>878</StateNumber>
+    </table>
+    <table id="37" parent="16" name="contains">
+      <ObjectId>197000</ObjectId>
+      <Owner>postgres</Owner>
+      <StateNumber>878</StateNumber>
+    </table>
+    <table id="38" parent="16" name="movie">
+      <ObjectId>196908</ObjectId>
+      <Owner>postgres</Owner>
+      <StateNumber>878</StateNumber>
+    </table>
+    <table id="39" parent="16" name="movie_employs">
+      <ObjectId>196937</ObjectId>
+      <Owner>postgres</Owner>
+      <StateNumber>878</StateNumber>
+    </table>
+    <table id="40" parent="16" name="produces">
+      <ObjectId>196985</ObjectId>
+      <Owner>postgres</Owner>
+      <StateNumber>878</StateNumber>
+    </table>
+    <table id="41" parent="16" name="produces_movie">
+      <ObjectId>196914</ObjectId>
+      <Owner>postgres</Owner>
+      <StateNumber>878</StateNumber>
+    </table>
+    <table id="42" parent="16" name="production">
+      <ObjectId>196954</ObjectId>
+      <Owner>postgres</Owner>
+      <StateNumber>878</StateNumber>
+    </table>
+    <table id="43" parent="16" name="production_company">
+      <ObjectId>196898</ObjectId>
+      <Owner>postgres</Owner>
+      <StateNumber>878</StateNumber>
+    </table>
+    <routine id="44" parent="16" name="update_all_broadcast_sizes">
+      <ObjectId>197017</ObjectId>
+      <Owner>postgres</Owner>
+      <SourceTextLength>256</SourceTextLength>
+      <StateNumber>878</StateNumber>
+      <VolatilityKind>volatile</VolatilityKind>
+      <LanguageName>plpgsql</LanguageName>
+      <RoutineKind>procedure</RoutineKind>
+      <Cost>100.0</Cost>
+    </routine>
+    <routine id="45" parent="16" name="update_all_broadcast_sizes_trigger">
+      <ObjectId>197018</ObjectId>
+      <Owner>postgres</Owner>
+      <SourceTextLength>68</SourceTextLength>
+      <StateNumber>878</StateNumber>
+      <VolatilityKind>volatile</VolatilityKind>
+      <ResultsDefinition>trigger</ResultsDefinition>
+      <LanguageName>plpgsql</LanguageName>
+      <RoutineKind>function</RoutineKind>
+      <Cost>100.0</Cost>
+    </routine>
+    <routine id="46" parent="16" name="update_episode_number">
+      <ObjectId>197016</ObjectId>
+      <Owner>postgres</Owner>
+      <SourceTextLength>447</SourceTextLength>
+      <StateNumber>878</StateNumber>
+      <VolatilityKind>volatile</VolatilityKind>
+      <ArgumentsDefinition>production_id_variable integer</ArgumentsDefinition>
+      <LanguageName>plpgsql</LanguageName>
+      <RoutineKind>procedure</RoutineKind>
+      <Cost>100.0</Cost>
+    </routine>
+    <routine id="47" parent="16" name="update_season_number">
+      <ObjectId>197015</ObjectId>
+      <Owner>postgres</Owner>
+      <SourceTextLength>457</SourceTextLength>
+      <StateNumber>878</StateNumber>
+      <VolatilityKind>volatile</VolatilityKind>
+      <ArgumentsDefinition>production_id_variable integer</ArgumentsDefinition>
+      <LanguageName>plpgsql</LanguageName>
+      <RoutineKind>procedure</RoutineKind>
+      <Cost>100.0</Cost>
+    </routine>
+    <column id="48" parent="34" name="id">
+      <Position>1</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <DefaultExpression>nextval(&apos;broadcast_id_seq&apos;::regclass)</DefaultExpression>
+      <TypeId>23</TypeId>
+    </column>
+    <column id="49" parent="34" name="name">
+      <Position>2</Position>
+      <DataType>varchar(250)|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>1043</TypeId>
+    </column>
+    <column id="50" parent="34" name="air_date">
+      <Position>3</Position>
+      <DataType>date|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>1082</TypeId>
+    </column>
+    <column id="51" parent="34" name="episode_number">
+      <Position>4</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>23</TypeId>
+    </column>
+    <column id="52" parent="34" name="season_number">
+      <Position>5</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>23</TypeId>
+    </column>
+    <index id="53" parent="34" name="broadcast_pk">
+      <ObjectId>196968</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>id</ColNames>
+      <Unique>1</Unique>
+      <Primary>1</Primary>
+    </index>
+    <key id="54" parent="34" name="broadcast_pk">
+      <ObjectId>196969</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>id</ColNames>
+      <Primary>1</Primary>
+      <UnderlyingIndexName>broadcast_pk</UnderlyingIndexName>
+    </key>
+    <column id="55" parent="35" name="broadcast_id">
+      <Position>1</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>23</TypeId>
+    </column>
+    <column id="56" parent="35" name="cast_id">
+      <Position>2</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>23</TypeId>
+    </column>
+    <column id="57" parent="35" name="role">
+      <Position>3</Position>
+      <DataType>varchar(255)|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>1043</TypeId>
+    </column>
+    <index id="58" parent="35" name="broadcast_employs_pkey">
+      <ObjectId>196973</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>broadcast_id
+cast_id</ColNames>
+      <Unique>1</Unique>
+      <Primary>1</Primary>
+    </index>
+    <key id="59" parent="35" name="broadcast_employs_pkey">
+      <ObjectId>196974</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>broadcast_id
+cast_id</ColNames>
+      <Primary>1</Primary>
+      <UnderlyingIndexName>broadcast_employs_pkey</UnderlyingIndexName>
+    </key>
+    <foreign-key id="60" parent="35" name="broadcast_employs_broadcast_id_fkey">
+      <ObjectId>196975</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>broadcast_id</ColNames>
+      <RefTableId>196964</RefTableId>
+      <RefColPositions>1</RefColPositions>
+      <RefTableName>broadcast</RefTableName>
+      <RefKeyName>broadcast_pk</RefKeyName>
+      <RefColNames>id</RefColNames>
+      <OnDelete>cascade</OnDelete>
+    </foreign-key>
+    <foreign-key id="61" parent="35" name="broadcast_employs_cast_id_fkey">
+      <ObjectId>196980</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>cast_id</ColNames>
+      <RefTableId>196931</RefTableId>
+      <RefColPositions>1</RefColPositions>
+      <RefTableName>cast_members</RefTableName>
+      <RefKeyName>cast_pk</RefKeyName>
+      <RefColNames>id</RefColNames>
+      <OnDelete>cascade</OnDelete>
+    </foreign-key>
+    <column id="62" parent="36" name="id">
+      <Position>1</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <DefaultExpression>nextval(&apos;cast_members_id_seq&apos;::regclass)</DefaultExpression>
+      <TypeId>23</TypeId>
+    </column>
+    <column id="63" parent="36" name="regdkid">
+      <Position>2</Position>
+      <DataType>varchar(10)|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>1043</TypeId>
+    </column>
+    <column id="64" parent="36" name="name">
+      <Position>3</Position>
+      <DataType>varchar(255)|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>1043</TypeId>
+    </column>
+    <index id="65" parent="36" name="cast_pk">
+      <ObjectId>196935</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>id</ColNames>
+      <Unique>1</Unique>
+      <Primary>1</Primary>
+    </index>
+    <key id="66" parent="36" name="cast_pk">
+      <ObjectId>196936</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>id</ColNames>
+      <Primary>1</Primary>
+      <UnderlyingIndexName>cast_pk</UnderlyingIndexName>
+    </key>
+    <column id="67" parent="37" name="production_id">
+      <Position>1</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>23</TypeId>
+    </column>
+    <column id="68" parent="37" name="broadcast_id">
+      <Position>2</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>23</TypeId>
+    </column>
+    <index id="69" parent="37" name="contains_pkey">
+      <ObjectId>197003</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>production_id
+broadcast_id</ColNames>
+      <Unique>1</Unique>
+      <Primary>1</Primary>
+    </index>
+    <key id="70" parent="37" name="contains_pkey">
+      <ObjectId>197004</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>production_id
+broadcast_id</ColNames>
+      <Primary>1</Primary>
+      <UnderlyingIndexName>contains_pkey</UnderlyingIndexName>
+    </key>
+    <foreign-key id="71" parent="37" name="contains_production_id_fkey">
+      <ObjectId>197005</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>production_id</ColNames>
+      <RefTableId>196954</RefTableId>
+      <RefColPositions>1</RefColPositions>
+      <RefTableName>production</RefTableName>
+      <RefKeyName>production_pk</RefKeyName>
+      <RefColNames>id</RefColNames>
+      <OnDelete>cascade</OnDelete>
+    </foreign-key>
+    <foreign-key id="72" parent="37" name="contains_broadcast_id_fkey">
+      <ObjectId>197010</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>broadcast_id</ColNames>
+      <RefTableId>196964</RefTableId>
+      <RefColPositions>1</RefColPositions>
+      <RefTableName>broadcast</RefTableName>
+      <RefKeyName>broadcast_pk</RefKeyName>
+      <RefColNames>id</RefColNames>
+      <OnDelete>cascade</OnDelete>
+    </foreign-key>
+    <trigger id="73" parent="37" name="update_size_of_broadcast_trigger">
+      <ObjectId>197019</ObjectId>
+      <StateNumber>878</StateNumber>
+      <Turn>after-stmt</Turn>
+      <Events>IUD</Events>
+      <FireMode>origin</FireMode>
+      <CallRoutineId>197018</CallRoutineId>
+    </trigger>
+    <column id="74" parent="38" name="id">
+      <Position>1</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <DefaultExpression>nextval(&apos;movie_id_seq&apos;::regclass)</DefaultExpression>
+      <TypeId>23</TypeId>
+    </column>
+    <column id="75" parent="38" name="name">
+      <Position>2</Position>
+      <DataType>varchar(250)|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>1043</TypeId>
+    </column>
+    <column id="76" parent="38" name="release_date">
+      <Position>3</Position>
+      <DataType>date|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>1082</TypeId>
+    </column>
+    <index id="77" parent="38" name="movie_pk">
+      <ObjectId>196912</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>id</ColNames>
+      <Unique>1</Unique>
+      <Primary>1</Primary>
+    </index>
+    <key id="78" parent="38" name="movie_pk">
+      <ObjectId>196913</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>id</ColNames>
+      <Primary>1</Primary>
+      <UnderlyingIndexName>movie_pk</UnderlyingIndexName>
+    </key>
+    <column id="79" parent="39" name="movie_id">
+      <Position>1</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>23</TypeId>
+    </column>
+    <column id="80" parent="39" name="cast_id">
+      <Position>2</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>23</TypeId>
+    </column>
+    <column id="81" parent="39" name="role">
+      <Position>3</Position>
+      <DataType>varchar(255)|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>1043</TypeId>
+    </column>
+    <index id="82" parent="39" name="movie_employs_pkey">
+      <ObjectId>196940</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>movie_id
+cast_id</ColNames>
+      <Unique>1</Unique>
+      <Primary>1</Primary>
+    </index>
+    <key id="83" parent="39" name="movie_employs_pkey">
+      <ObjectId>196941</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>movie_id
+cast_id</ColNames>
+      <Primary>1</Primary>
+      <UnderlyingIndexName>movie_employs_pkey</UnderlyingIndexName>
+    </key>
+    <foreign-key id="84" parent="39" name="movie_employs_movie_id_fkey">
+      <ObjectId>196942</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>movie_id</ColNames>
+      <RefTableId>196908</RefTableId>
+      <RefColPositions>1</RefColPositions>
+      <RefTableName>movie</RefTableName>
+      <RefKeyName>movie_pk</RefKeyName>
+      <RefColNames>id</RefColNames>
+      <OnDelete>cascade</OnDelete>
+    </foreign-key>
+    <foreign-key id="85" parent="39" name="movie_employs_cast_id_fkey">
+      <ObjectId>196947</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>cast_id</ColNames>
+      <RefTableId>196931</RefTableId>
+      <RefColPositions>1</RefColPositions>
+      <RefTableName>cast_members</RefTableName>
+      <RefKeyName>cast_pk</RefKeyName>
+      <RefColNames>id</RefColNames>
+      <OnDelete>cascade</OnDelete>
+    </foreign-key>
+    <column id="86" parent="40" name="production_company_id">
+      <Position>1</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>23</TypeId>
+    </column>
+    <column id="87" parent="40" name="production_id">
+      <Position>2</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>23</TypeId>
+    </column>
+    <index id="88" parent="40" name="produces_pkey">
+      <ObjectId>196988</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>production_company_id
+production_id</ColNames>
+      <Unique>1</Unique>
+      <Primary>1</Primary>
+    </index>
+    <key id="89" parent="40" name="produces_pkey">
+      <ObjectId>196989</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>production_company_id
+production_id</ColNames>
+      <Primary>1</Primary>
+      <UnderlyingIndexName>produces_pkey</UnderlyingIndexName>
+    </key>
+    <foreign-key id="90" parent="40" name="produces_production_company_id_fkey">
+      <ObjectId>196990</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>production_company_id</ColNames>
+      <RefTableId>196898</RefTableId>
+      <RefColPositions>1</RefColPositions>
+      <RefTableName>production_company</RefTableName>
+      <RefKeyName>production_company_pk</RefKeyName>
+      <RefColNames>id</RefColNames>
+      <OnDelete>cascade</OnDelete>
+    </foreign-key>
+    <foreign-key id="91" parent="40" name="produces_production_id_fkey">
+      <ObjectId>196995</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>production_id</ColNames>
+      <RefTableId>196954</RefTableId>
+      <RefColPositions>1</RefColPositions>
+      <RefTableName>production</RefTableName>
+      <RefKeyName>production_pk</RefKeyName>
+      <RefColNames>id</RefColNames>
+      <OnDelete>cascade</OnDelete>
+    </foreign-key>
+    <column id="92" parent="41" name="production_company_id">
+      <Position>1</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>23</TypeId>
+    </column>
+    <column id="93" parent="41" name="movie_id">
+      <Position>2</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>23</TypeId>
+    </column>
+    <index id="94" parent="41" name="produces_movie_pkey">
+      <ObjectId>196917</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>production_company_id
+movie_id</ColNames>
+      <Unique>1</Unique>
+      <Primary>1</Primary>
+    </index>
+    <key id="95" parent="41" name="produces_movie_pkey">
+      <ObjectId>196918</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>production_company_id
+movie_id</ColNames>
+      <Primary>1</Primary>
+      <UnderlyingIndexName>produces_movie_pkey</UnderlyingIndexName>
+    </key>
+    <foreign-key id="96" parent="41" name="produces_movie_production_company_id_fkey">
+      <ObjectId>196919</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>production_company_id</ColNames>
+      <RefTableId>196898</RefTableId>
+      <RefColPositions>1</RefColPositions>
+      <RefTableName>production_company</RefTableName>
+      <RefKeyName>production_company_pk</RefKeyName>
+      <RefColNames>id</RefColNames>
+      <OnDelete>cascade</OnDelete>
+    </foreign-key>
+    <foreign-key id="97" parent="41" name="produces_movie_movie_id_fkey">
+      <ObjectId>196924</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>movie_id</ColNames>
+      <RefTableId>196908</RefTableId>
+      <RefColPositions>1</RefColPositions>
+      <RefTableName>movie</RefTableName>
+      <RefKeyName>movie_pk</RefKeyName>
+      <RefColNames>id</RefColNames>
+      <OnDelete>cascade</OnDelete>
+    </foreign-key>
+    <column id="98" parent="42" name="id">
+      <Position>1</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <DefaultExpression>nextval(&apos;production_id_seq&apos;::regclass)</DefaultExpression>
+      <TypeId>23</TypeId>
+    </column>
+    <column id="99" parent="42" name="name">
+      <Position>2</Position>
+      <DataType>varchar(255)|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>1043</TypeId>
+    </column>
+    <column id="100" parent="42" name="year">
+      <Position>3</Position>
+      <DataType>date|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>1082</TypeId>
+    </column>
+    <column id="101" parent="42" name="number_of_seasons">
+      <Position>4</Position>
+      <DataType>integer|0s</DataType>
+      <StateNumber>878</StateNumber>
+      <DefaultExpression>0</DefaultExpression>
+      <TypeId>23</TypeId>
+    </column>
+    <column id="102" parent="42" name="number_of_episodes">
+      <Position>5</Position>
+      <DataType>integer|0s</DataType>
+      <StateNumber>878</StateNumber>
+      <DefaultExpression>0</DefaultExpression>
+      <TypeId>23</TypeId>
+    </column>
+    <index id="103" parent="42" name="production_pk">
+      <ObjectId>196960</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>id</ColNames>
+      <Unique>1</Unique>
+      <Primary>1</Primary>
+    </index>
+    <key id="104" parent="42" name="production_pk">
+      <ObjectId>196961</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>id</ColNames>
+      <Primary>1</Primary>
+      <UnderlyingIndexName>production_pk</UnderlyingIndexName>
+    </key>
+    <column id="105" parent="43" name="id">
+      <Position>1</Position>
+      <DataType>integer|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <DefaultExpression>nextval(&apos;production_company_id_seq&apos;::regclass)</DefaultExpression>
+      <TypeId>23</TypeId>
+    </column>
+    <column id="106" parent="43" name="name">
+      <Position>2</Position>
+      <DataType>varchar(250)|0s</DataType>
+      <NotNull>1</NotNull>
+      <StateNumber>878</StateNumber>
+      <TypeId>1043</TypeId>
+    </column>
+    <index id="107" parent="43" name="production_company_pk">
+      <ObjectId>196902</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>id</ColNames>
+      <Unique>1</Unique>
+      <Primary>1</Primary>
+    </index>
+    <index id="108" parent="43" name="production_company_name_key">
+      <ObjectId>196904</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>name</ColNames>
+      <Unique>1</Unique>
+    </index>
+    <key id="109" parent="43" name="production_company_pk">
+      <ObjectId>196903</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>id</ColNames>
+      <Primary>1</Primary>
+      <UnderlyingIndexName>production_company_pk</UnderlyingIndexName>
+    </key>
+    <key id="110" parent="43" name="production_company_name_key">
+      <ObjectId>196905</ObjectId>
+      <StateNumber>878</StateNumber>
+      <ColNames>name</ColNames>
+      <UnderlyingIndexName>production_company_name_key</UnderlyingIndexName>
+    </key>
+    <argument id="111" parent="44">
+      <ArgumentDirection>R</ArgumentDirection>
+      <DataType>void|0s</DataType>
+    </argument>
+    <argument id="112" parent="45">
+      <ArgumentDirection>R</ArgumentDirection>
+      <DataType>trigger|0s</DataType>
+    </argument>
+    <argument id="113" parent="46" name="production_id_variable">
+      <Position>1</Position>
+      <DataType>integer|0s</DataType>
+    </argument>
+    <argument id="114" parent="46">
+      <ArgumentDirection>R</ArgumentDirection>
+      <DataType>void|0s</DataType>
+    </argument>
+    <argument id="115" parent="47" name="production_id_variable">
+      <Position>1</Position>
+      <DataType>integer|0s</DataType>
+    </argument>
+    <argument id="116" parent="47">
+      <ArgumentDirection>R</ArgumentDirection>
+      <DataType>void|0s</DataType>
+    </argument>
+  </database-model>
+</dataSource>

--- a/CredIT/src/main/java/org/openjfx/presentation/App.java
+++ b/CredIT/src/main/java/org/openjfx/presentation/App.java
@@ -265,11 +265,11 @@ public class App extends Application {
      * @author Sarah
      * @return returns the roleArray to be used for setting items in the ListView displaying all movie roles
      */
-    public static ArrayList<PCast> getMovieRoleArray(){
+    public static ArrayList<PCast> getMovieRoleArray(IMovie chosenMovie){
         if(!roleArray.isEmpty()) {
             roleArray.clear();
         }else{
-            HashMap<ICast, String> movieRoles = new HashMap<>(ModifyMovieController.getChosenMovie().getCastMap());
+            HashMap<ICast, String> movieRoles = new HashMap<>(chosenMovie.getCastMap());
 
             for (ICast cast : movieRoles.keySet()) {
                 PCast newCast = new PCast(cast, movieRoles.get(cast));
@@ -286,11 +286,11 @@ public class App extends Application {
      * @author Sarah
      * @return returns the roleArray to be used for setting items in the ListView displaying all broadcast roles
      */
-    public static ArrayList<PCast> getBroadcastRoleArray(){
+    public static ArrayList<PCast> getBroadcastRoleArray(IBroadcast chosenBroadcast){
         if(!roleArray.isEmpty()) {
             roleArray.clear();
         }else {
-            HashMap<ICast, String> broadcastRoles = new HashMap<>(ModifyBroadcastController.getChosenBroadcast().getCastMap());
+            HashMap<ICast, String> broadcastRoles = new HashMap<>(chosenBroadcast.getCastMap());
 
             for (ICast cast : broadcastRoles.keySet()) {
                 PCast newCast = new PCast(cast, broadcastRoles.get(cast));

--- a/CredIT/src/main/java/org/openjfx/presentation/AssignUnassignCastController.java
+++ b/CredIT/src/main/java/org/openjfx/presentation/AssignUnassignCastController.java
@@ -244,10 +244,10 @@ public class AssignUnassignCastController implements Initializable {
 
         if (App.getAssignCastModifier().equals("movie")) {
             resultList.getItems().clear();
-            resultList.setItems(FXCollections.observableArrayList(App.getMovieRoleArray()));
+            resultList.setItems(FXCollections.observableArrayList(App.getMovieRoleArray(ModifyMovieController.getChosenMovie())));
         } else if (App.getAssignCastModifier().equals("broadcast")) {
             resultList.getItems().clear();
-            resultList.setItems(FXCollections.observableArrayList(App.getBroadcastRoleArray()));
+            resultList.setItems(FXCollections.observableArrayList(App.getBroadcastRoleArray(ModifyBroadcastController.getChosenBroadcast())));
         }
 
         clearFields();

--- a/CredIT/src/main/java/org/openjfx/presentation/GuestUserPageController.java
+++ b/CredIT/src/main/java/org/openjfx/presentation/GuestUserPageController.java
@@ -129,10 +129,8 @@ public class GuestUserPageController implements Initializable {
     //Variables/attributes used in this controller
     //region
     private String searchTopicChosen;
-
     private ArrayList<IProduction> productionList;
     private ArrayList<IMovie> movieList;
-
     private Object obj;
     private String searchText;
     private ICast chosenCast;

--- a/CredIT/src/main/java/org/openjfx/presentation/GuestUserPageController.java
+++ b/CredIT/src/main/java/org/openjfx/presentation/GuestUserPageController.java
@@ -444,7 +444,7 @@ public class GuestUserPageController implements Initializable {
      */
     @FXML
     public void handleShowCastBroadcast(MouseEvent event) {
-        resultList.setItems(FXCollections.observableArrayList(App.getBroadcastRoleArray()));
+        resultList.setItems(FXCollections.observableArrayList(App.getBroadcastRoleArray(chosenBroadcast)));
         chosenBroadcast = null;
     }
 
@@ -456,7 +456,7 @@ public class GuestUserPageController implements Initializable {
      */
     @FXML
     public void handleShowCastMovie(MouseEvent event) {
-        resultList.setItems(FXCollections.observableArrayList(App.getMovieRoleArray()));
+        resultList.setItems(FXCollections.observableArrayList(App.getMovieRoleArray(chosenMovie)));
         chosenMovie = null;
     }
 

--- a/CredIT/src/main/java/org/openjfx/presentation/ModifyMovieController.java
+++ b/CredIT/src/main/java/org/openjfx/presentation/ModifyMovieController.java
@@ -119,7 +119,6 @@ public class ModifyMovieController implements Initializable {
     public void handleResultChosen(MouseEvent event) {
         resultList.setDisable(false);
         chosenMovie = (IMovie) resultList.getSelectionModel().getSelectedItem();
-        System.out.println(chosenMovie);
         setFieldsText(chosenMovie);
         changeCast.setDisable(false);
         delete.setDisable(false);

--- a/CredIT/src/main/java/org/openjfx/presentation/ModifyProductionController.java
+++ b/CredIT/src/main/java/org/openjfx/presentation/ModifyProductionController.java
@@ -281,7 +281,6 @@ public class ModifyProductionController implements Initializable {
     private void setFieldsText(IProduction production){
         productionName.setText(production.getName());
         releaseYear.setText(production.getYear());
-
         IProductionCompany retrievedProductionCompany = App.retrieveProductionCompanyForProduction(production);
         productionCompany.setText(retrievedProductionCompany.getName());
         amountOfEpisodes.setText(String.valueOf(production.getNumberOfEpisodes()));


### PR DESCRIPTION
The standardised method for dealing with iterating through the movie/broadcast role HashMap used the chosenMovie from the ModifyMovieController scene, and not the movie that was chosen in the guest page, therefore always using null. 

Now, to fix the issue, the method takes an IMovie/IBroadcast parameter, which allows for setting the desired chosenMovie/chosenBroadcast, therefore eliminating the issue. 